### PR TITLE
Update Homebrew installation syntax

### DIFF
--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -12,7 +12,7 @@ permalink: /
 
 [**Download the latest release**]({{ site.github.latest_release.assets[0].browser_download_url }})
 
-Alternatively, you can use [homebrew](https://brew.sh/): `brew cask install alt-tab`
+Alternatively, you can use [homebrew](https://brew.sh/): `brew install --cask alt-tab`
 
 ## Compatibility
 


### PR DESCRIPTION
This is an extremely minor documentation update.

Homebrew has [disabled](https://formulae.brew.sh/cask/alt-tab#default) the use of `brew cask install [package]` in favor of `brew install --cask [package]`. You can also see this on the Homebrew Formulae [website](https://formulae.brew.sh/cask/alt-tab#default).

Thank you for opening a PR! Please make sure that:
